### PR TITLE
Fixes selection state after clicking Cancel and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ selected: {start: Moment, end: Moment};
 You can [play with our online demo here](https://fetrarij.github.io/ngx-daterangepicker-material/)
 and [browse our demo code here](./demo/src/app).
 
+## Inline usage
+
+You can use the component directly in your templates, which will set its `inline` mode to **true**, in which case the calendar won't hide after date/range selection. You can then use the events (`rangeClicked` or `datesUpdated`) to get its selection state.
+
+```html
+<ngx-daterangepicker-material (choosedDate)="choosedDate($event)">
+</ngx-daterangepicker-material>
+```
 
 
 ## Available options

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and [browse our demo code here](./demo/src/app).
 
 ## Inline usage
 
-You can use the component directly in your templates, which will set its `inline` mode to **true**, in which case the calendar won't hide after date/range selection. You can then use the events (`rangeClicked` or `datesUpdated`) to get its selection state.
+You can use the component directly in your templates, which will set its `inline` mode to **true**, in which case the calendar won't hide after date/range selection. You can then use the events: `rangeClicked` or `datesUpdated` or `choosedDate` to get its selection state.
 
 ```html
 <ngx-daterangepicker-material (choosedDate)="choosedDate($event)">

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -1,9 +1,9 @@
-<a class="hide-on-med-and-down hidden-xs" href="//github.com/fetrarij/ngx-daterangepicker-material" >
+<a class="hide-on-small-only hidden-xs" href="//github.com/fetrarij/ngx-daterangepicker-material" >
   <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 2000" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
 </a>
 <nav class="light-blue lighten-1" role="navigation">
   <div class="nav-wrapper container">
-    <ul class="left hide-on-med-and-down">
+    <ul class="left hide-on-small-only">
       <li routerLinkActive="active"><a [routerLink]="['simple']">Simple</a></li>
       <li routerLinkActive="active"><a [routerLink]="['single-datepicker']">Single datepicker</a></li>
       <li routerLinkActive="active"><a [routerLink]="['custom-ranges']">Custom ranges</a></li>

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -115,6 +115,10 @@ export class DaterangepickerComponent implements OnInit {
                 iterator--;
             }
         }
+        if(this.inline) {
+            this._old.start = this.startDate.clone();
+            this._old.end = this.endDate.clone();
+        }
         this.renderCalendar(SideEnum.left);
         this.renderCalendar(SideEnum.right);
         this.renderRanges();
@@ -574,6 +578,9 @@ export class DaterangepickerComponent implements OnInit {
         this.startDate = this._old.start;
         this.endDate = this._old.end;
         this.datesUpdated.emit({startDate: this.startDate, endDate: this.endDate});
+        if(this.inline) {
+            this.updateView();
+        }
         this.hide();
     }
     /**


### PR DESCRIPTION
There was a bug in the inline mode where after clicking _Cancel_, the selected dates would be set to `null`, which would cause an error next time a date was clicked. 

The error was caused by the fact that in _inline_ mode the `show()` method was never explicitly called and `_old` object was never set to the default calendar selection.

This fixes it, as well as adds the _inline_ mode description in the README.