### PR TITLE
fixed directive locale input

### DIFF
--- a/src/daterangepicker/daterangepicker.directive.ts
+++ b/src/daterangepicker/daterangepicker.directive.ts
@@ -102,7 +102,7 @@ export class DaterangepickerDirective implements OnInit, OnChanges, DoCheck {
   timePickerSeconds: Boolean = false;
   _locale: LocaleConfig = {};
   @Input() set locale(value) {
-    this._locale = {...value, ...this.localeConfig};
+    this._locale = {...this.localeConfig, ...value};
   }
   get locale(): any {
     return this._locale;


### PR DESCRIPTION
`this.locale = {...this.localeConfig, ...value};` was in the wrong order which resulted in the default config overwriting the parameter value.