### PR TITLE
Allow ranges to be swapped dynamically

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -99,7 +99,7 @@ export class DaterangepickerComponent implements OnInit {
         this.renderRanges();
     }
     get ranges(): any {
-        return this.ranges;
+        return this._ranges;
     }
 
     @Input()

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -92,8 +92,16 @@ export class DaterangepickerComponent implements OnInit {
       return this._locale;
     }
     // custom ranges
-    @Input()
-    ranges: any = {};
+    _ranges: any = {};
+
+    @Input() set ranges(value) {
+        this._ranges = value;
+        this.renderRanges();
+    }
+    get ranges(): any {
+        return this.ranges;
+    }
+
     @Input()
     showCustomRangeLabel: boolean;
     @Input()
@@ -156,6 +164,7 @@ export class DaterangepickerComponent implements OnInit {
         this.renderRanges();
     }
     renderRanges() {
+        this.rangesArray = [];
         let start, end;
         if (typeof this.ranges === 'object') {
             for (const range in this.ranges) {

--- a/src/daterangepicker/daterangepicker.directive.ts
+++ b/src/daterangepicker/daterangepicker.directive.ts
@@ -102,7 +102,7 @@ export class DaterangepickerDirective implements OnInit, OnChanges, DoCheck {
   timePickerSeconds: Boolean = false;
   _locale: LocaleConfig = {};
   @Input() set locale(value) {
-    this._locale = {...value, ...this.localeConfig};
+    this._locale = {...this.localeConfig, ...value};
   }
   get locale(): any {
     return this._locale;


### PR DESCRIPTION
Before this change the ranges were initialized only once (in onInit).
That means if you change the ranges object, nothing changes in the component.

I fixed this by calling the "renderRanges" function whenever the ranges value is set.

This was needed when hotswapping translations.