### PR TITLE
 Fix for calendars not updating view when a range is clicked

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -921,8 +921,10 @@ export class DaterangepickerComponent implements OnInit {
             if (!this.keepCalendarOpeningWithRange) {
                 this.clickApply();
             } else {
-                this.renderCalendar(SideEnum.left);
-                this.renderCalendar(SideEnum.right);
+                this.leftCalendar.month.month(dates[0].month());
+                this.leftCalendar.month.year(dates[0].year());
+                this.rightCalendar.month.month(dates[1].month());
+                this.rightCalendar.month.year(dates[1].year());
                 if (this.timePicker) {
                     this.renderTimePicker(SideEnum.left)
                     this.renderTimePicker(SideEnum.right)

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -925,6 +925,7 @@ export class DaterangepickerComponent implements OnInit {
                 this.leftCalendar.month.year(dates[0].year());
                 this.rightCalendar.month.month(dates[1].month());
                 this.rightCalendar.month.year(dates[1].year());
+                this.updateCalendars();
                 if (this.timePicker) {
                     this.renderTimePicker(SideEnum.left)
                     this.renderTimePicker(SideEnum.right)


### PR DESCRIPTION
When clicking one of the ranges in the calendar, the calendars themselves don't jump over to that specific range, thus if a user is in a different month or year, he won't see the range he just clicked.