### PR TITLE
Update daterangepicker.directive.ts

### DIFF
--- a/src/daterangepicker/daterangepicker.directive.ts
+++ b/src/daterangepicker/daterangepicker.directive.ts
@@ -307,7 +307,7 @@ export class DaterangepickerDirective implements OnInit, OnChanges, DoCheck {
    * @param targetElement target element object
    */
   @HostListener('document:click', ['$event', '$event.target'])
-  outsideClick(event, targetElement: HTMLElement): void {
+  outsideClick(event, targetElement: any): void {
       if (!targetElement) {
         return;
       }


### PR DESCRIPTION
Removed HTMLElement so that SSR doesn't error.

More info: #143 

I think that you might want to look into where `HTMLElement` comes from but this does actually fix it. 