### PR TITLE
adds LocaleConfig displayFormat to have custom format of date display

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ demo:  https://fetrarij.github.io/ngx-daterangepicker-material/
 ## Installation
 
  Install the plugin from npm:
- 
+
  `npm install ngx-daterangepicker-material --save` .
 
  import **NgxDaterangepickerMd** in your module:
@@ -32,8 +32,8 @@ import { App } from './app';
 
 @NgModule({
     imports: [
-        ... , 
-        FormsModule, 
+        ... ,
+        FormsModule,
         NgxDaterangepickerMd.forRoot()
     ],
     declarations: [App],
@@ -49,12 +49,12 @@ Html:
 ```html
 <input type="text" ngxDaterangepickerMd [(ngModel)]="selected" class="form-control"/>
 ```
-Typescript: 
+Typescript:
 
 ````typescript
 selected: {startDate: Moment, endDate: Moment};
 ````
-### with some options: 
+### with some options:
 Html:
 
 ```html
@@ -66,7 +66,7 @@ Html:
     [(ngModel)]="selected"
     name="daterange"/>
 ```
-Typescript: 
+Typescript:
 
 ````typescript
 selected: {start: Moment, end: Moment};
@@ -107,10 +107,11 @@ You can use the component directly in your templates, which will set its `inline
 
 ### locale
 
->the locale options is an object with: 
+>the locale options is an object with:
 ```javascript
 {
-    format: 'MM/DD/YYYY',
+    format: 'MM/DD/YYYY', // could be 'YYYY-MM-DDTHH:mm:ss.SSSSZ'
+    displayFormat: 'MM/DD/YYYY', // default is format value
     direction: 'ltr', // could be rtl
     weekLabel: 'W',
     separator: ' To ', // default is ' - '
@@ -131,7 +132,7 @@ Theses 2 options are for the key you want for the value, default are `startDate`
 
 Specifiyng `startKey` and `endKey` would have different model:
 
-example: 
+example:
 ```html
 <input type="text" ngxDaterangepickerMd startKey="start" endKey="end" [(ngModel)]="model">
 ```
@@ -215,10 +216,10 @@ eg:
 ```
 @NgModule({
     imports: [
-        ... , 
-        FormsModule, 
+        ... ,
+        FormsModule,
         NgxDaterangepickerMd.forRoot({
-            separator: ' - ', 
+            separator: ' - ',
             applyLabel: 'Okay',
         })
     ],
@@ -232,7 +233,7 @@ eg:
 ### Prepare your environment
 
 Install local dependencies: `npm install`.
- 
+
 ### Development server
 
 Run `npm start` to start a development server on a port 4200.

--- a/demo/src/app/full/full.component.ts
+++ b/demo/src/app/full/full.component.ts
@@ -26,7 +26,8 @@ export class FullComponent implements OnInit {
   minDate: moment.Moment = moment().subtract(5, 'days');
   maxDate: moment.Moment = moment().add(2, 'month');
   locale: any = {
-    format: 'DD MMMM YYYY HH:mm',
+    format: 'YYYY-MM-DDTHH:mm:ss.SSSSZ',
+    displayFormat: 'DD MMMM YYYY HH:mm',
     separator: ' To ',
     cancelLabel: 'Cancel',
     applyLabel: 'Okay'

--- a/demo/src/app/reactive-form/reactive-form.component.html
+++ b/demo/src/app/reactive-form/reactive-form.component.html
@@ -1,10 +1,34 @@
 <mat-toolbar>Reactive forms</mat-toolbar>
 <form [formGroup]="form" (ngSubmit)="submit()">
   <div class="row">
+    <div class="col s12">
+      <h6>Multi Select</h6>
+    </div>
     <div class="col s6">
         <input type="text" ngxDaterangepickerMd
         formControlName="selected" class="form-control" placeholder="Choose date"
         [showDropdowns]="true"
+        showCancel="true"
+        />
+    </div>
+    <div class="col s6">
+      <br/>
+      <button type="submit" class="ngx-daterangepicker-action waves-effect waves-light btn" >Submit</button>
+    </div>
+  </div>
+</form>
+
+<form [formGroup]="form2" (ngSubmit)="submit2()">
+  <div class="row">
+    <div class="col s12">
+      <h6>Single Select</h6>
+    </div>
+    <div class="col s6">
+        <input type="text" ngxDaterangepickerMd
+        formControlName="selected" class="form-control" placeholder="Choose date"
+        [showDropdowns]="true"
+        [singleDatePicker]="true"
+        [locale]="locale"
         showCancel="true"
         />
     </div>

--- a/demo/src/app/reactive-form/reactive-form.component.ts
+++ b/demo/src/app/reactive-form/reactive-form.component.ts
@@ -1,14 +1,21 @@
 import { Component, OnInit } from '@angular/core';
 import * as moment from 'moment';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { LocaleConfig } from '../../../../src/daterangepicker';
 
 @Component({
   selector: 'reactive-form',
   templateUrl: './reactive-form.component.html',
   styleUrls: ['./reactive-form.component.scss']
 })
-export class ReactiveFormComponent implements OnInit {
+export class ReactiveFormComponent {
   form: FormGroup;
+  form2: FormGroup;
+  locale: LocaleConfig = {
+    format: 'YYYY-MM-DDTHH:mm:ss.SSSSZ',
+    displayFormat: 'YYYY-MM-DD',
+  };
+
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group({
       selected: [{
@@ -16,11 +23,20 @@ export class ReactiveFormComponent implements OnInit {
         endDate: moment('2015-11-26T00:00Z')
       }, Validators.required],
     });
+
+    this.form2 = this.fb.group({
+      selected: [{
+        startDate: '2019-12-11T18:30:00.000Z',
+        endDate: '2019-12-12T18:29:59.000Z',
+      }, Validators.required],
+    });
    }
 
-  ngOnInit() {
-  }
   submit() {
-    console.log(this.form.value)
+    console.log(this.form.value);
+  }
+
+  submit2() {
+    console.log(this.form2.value);
   }
 }

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -614,6 +614,7 @@ export class DaterangepickerComponent implements OnInit {
         this.calculateChosenLabel();
     }
     updateElement() {
+        const format = this.locale.displayFormat ? this.locale.displayFormat : this.locale.format;
         if (!this.singleDatePicker && this.autoUpdateInput) {
             if (this.startDate && this.endDate) {
                 // if we use ranges and should show range label on input
@@ -621,12 +622,12 @@ export class DaterangepickerComponent implements OnInit {
                     this.locale.customRangeLabel !== this.chosenRange) {
                     this.chosenLabel = this.chosenRange;
                 } else {
-                    this.chosenLabel = this.startDate.format(this.locale.format) +
-                    this.locale.separator + this.endDate.format(this.locale.format);
+                    this.chosenLabel = this.startDate.format(format) +
+                    this.locale.separator + this.endDate.format(format);
                 }
             }
         } else if ( this.autoUpdateInput) {
-            this.chosenLabel = this.startDate.format(this.locale.format);
+            this.chosenLabel = this.startDate.format(format);
         }
     }
 

--- a/src/daterangepicker/daterangepicker.config.ts
+++ b/src/daterangepicker/daterangepicker.config.ts
@@ -18,6 +18,7 @@ export interface LocaleConfig {
     monthNames?:  string[];
     firstDay?: number;
     format?: string;
+    displayFormat?: string;
 }
 /**
  *  DefaultLocaleConfig


### PR DESCRIPTION
There is an issue while using it as a single date picker.

While in the edit mode of any existing reactive form, patching values result in selecting 2 dates.

**Example:**
If I selected a date with a single date picker, it gives value like below (selected 2019-12-12).
{ "startDate": "2019-12-11T18:30:00.000Z", "endDate": "2019-12-12T18:29:59.000Z" } 

If I patch the same value to select the date, it selects 2 dates.
![single-date](https://user-images.githubusercontent.com/856090/71639151-11e31500-2c97-11ea-8b4b-b2701fc68c1b.png)

The date picker always returns in TZ format, so the fix is to set local format to TZ and have an option to show custom display format.
