### PR TITLE
232 time selector is always enabled

### DIFF
--- a/src/daterangepicker/daterangepicker.component.html
+++ b/src/daterangepicker/daterangepicker.component.html
@@ -89,14 +89,14 @@
         </div>
         <div class="calendar-time" *ngIf="timePicker">
             <div class="select">
-                <select class="hourselect select-item" [disabled]="!endDate" [(ngModel)]="timepickerVariables.left.selectedHour" (ngModelChange)="timeChanged($event, sideEnum.left)">
+                <select class="hourselect select-item" [disabled]="!startDate" [(ngModel)]="timepickerVariables.left.selectedHour" (ngModelChange)="timeChanged($event, sideEnum.left)">
                     <option *ngFor="let i of timepickerVariables.left.hours"
                     [value]="i"
                     [disabled]="timepickerVariables.left.disabledHours.indexOf(i) > -1">{{i}}</option>
                 </select>
             </div>
             <div class="select">
-                <select class="select-item minuteselect" [disabled]="!endDate" [(ngModel)]="timepickerVariables.left.selectedMinute" (ngModelChange)="timeChanged($event, sideEnum.left)">
+                <select class="select-item minuteselect" [disabled]="!startDate" [(ngModel)]="timepickerVariables.left.selectedMinute" (ngModelChange)="timeChanged($event, sideEnum.left)">
                     <option *ngFor="let i of timepickerVariables.left.minutes; let index = index;"
                     [value]="i"
                     [disabled]="timepickerVariables.left.disabledMinutes.indexOf(i) > -1">{{timepickerVariables.left.minutesLabel[index]}}</option>
@@ -105,7 +105,7 @@
                 <span class="select-bar"></span>
             </div>
             <div class="select">
-                <select class="select-item secondselect" *ngIf="timePickerSeconds" [disabled]="!endDate" [(ngModel)]="timepickerVariables.left.selectedSecond" (ngModelChange)="timeChanged($event, sideEnum.left)">
+                <select class="select-item secondselect" *ngIf="timePickerSeconds" [disabled]="!startDate" [(ngModel)]="timepickerVariables.left.selectedSecond" (ngModelChange)="timeChanged($event, sideEnum.left)">
                     <option *ngFor="let i of timepickerVariables.left.seconds; let index = index;"
                     [value]="i"
                     [disabled]="timepickerVariables.left.disabledSeconds.indexOf(i) > -1">{{timepickerVariables.left.secondsLabel[index]}}</option>
@@ -194,7 +194,7 @@
         </div>
         <div class="calendar-time" *ngIf="timePicker">
             <div class="select">
-                <select class="select-item hourselect" [disabled]="!endDate" [(ngModel)]="timepickerVariables.right.selectedHour" (ngModelChange)="timeChanged($event, sideEnum.right)">
+                <select class="select-item hourselect" [disabled]="!startDate" [(ngModel)]="timepickerVariables.right.selectedHour" (ngModelChange)="timeChanged($event, sideEnum.right)">
                     <option *ngFor="let i of timepickerVariables.right.hours"
                     [value]="i"
                     [disabled]="timepickerVariables.right.disabledHours.indexOf(i) > -1">{{i}}</option>
@@ -203,7 +203,7 @@
                 <span class="select-bar"></span>
             </div>
             <div class="select">
-                <select class="select-item minuteselect" [disabled]="!endDate" [(ngModel)]="timepickerVariables.right.selectedMinute" (ngModelChange)="timeChanged($event, sideEnum.right)">
+                <select class="select-item minuteselect" [disabled]="!startDate" [(ngModel)]="timepickerVariables.right.selectedMinute" (ngModelChange)="timeChanged($event, sideEnum.right)">
                     <option *ngFor="let i of timepickerVariables.right.minutes; let index = index;"
                     [value]="i"
                     [disabled]="timepickerVariables.right.disabledMinutes.indexOf(i) > -1">{{timepickerVariables.right.minutesLabel[index]}}</option>
@@ -212,7 +212,7 @@
                 <span class="select-bar"></span>
             </div>
             <div class="select">
-                <select *ngIf="timePickerSeconds" class="select-item secondselect" [disabled]="!endDate" [(ngModel)]="timepickerVariables.right.selectedSecond" (ngModelChange)="timeChanged($event, sideEnum.right)">
+                <select *ngIf="timePickerSeconds" class="select-item secondselect" [disabled]="!startDate" [(ngModel)]="timepickerVariables.right.selectedSecond" (ngModelChange)="timeChanged($event, sideEnum.right)">
                     <option *ngFor="let i of timepickerVariables.right.seconds; let index = index;"
                     [value]="i"
                     [disabled]="timepickerVariables.right.disabledSeconds.indexOf(i) > -1">{{timepickerVariables.right.secondsLabel[index]}}</option>

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -1,12 +1,9 @@
-import {
-    Component, OnInit, ElementRef, ViewChild, EventEmitter, Output, Input, forwardRef, ViewEncapsulation, ChangeDetectorRef, Inject
-} from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { FormControl} from '@angular/forms';
-import { LocaleConfig } from './daterangepicker.config';
-
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 import * as _moment from 'moment';
+import { LocaleConfig } from './daterangepicker.config';
 import { LocaleService } from './locale.service';
+
 const moment = _moment;
 
 export enum SideEnum {
@@ -243,17 +240,21 @@ export class DaterangepickerComponent implements OnInit {
         }
 
     }
-    renderTimePicker(side: SideEnum) {
-        if (side === SideEnum.right && !this.endDate) {
-            return;
-        }
+    renderTimePicker(side: SideEnum) {        
         let selected, minDate;
         const maxDate = this.maxDate;
         if (side === SideEnum.left) {
             selected = this.startDate.clone(),
             minDate = this.minDate;
-        } else if (side === SideEnum.right) {
+        } else if (side === SideEnum.right && this.endDate) {
             selected = this.endDate.clone(),
+            minDate = this.startDate;
+        } else if (side === SideEnum.right && !this.endDate) {
+            // don't have an end date, use the start date then put the selected time for the right side as the time
+            selected = this._getDateWithTime(this.startDate, SideEnum.right);
+            if(selected.isBefore(this.startDate)){
+                selected = this.startDate.clone();  //set it back to the start date the time was backwards
+            }
             minDate = this.startDate;
         }
         const start = this.timePicker24Hour ? 0 : 1;
@@ -294,6 +295,7 @@ export class DaterangepickerComponent implements OnInit {
                 this.timepickerVariables[side].disabledHours.push(i);
             }
         }
+        
         // generate minutes
         for (let i = 0; i < 60; i += this.timePickerIncrement) {
             const padded = i < 10 ? '0' + i : i;
@@ -689,7 +691,8 @@ export class DaterangepickerComponent implements OnInit {
 
     clickApply(e?) {
         if (!this.singleDatePicker && this.startDate && !this.endDate) {
-            this.endDate = this.startDate.clone();
+            this.endDate = this._getDateWithTime(this.startDate, SideEnum.right);
+
             this.calculateChosenLabel();
         }
         if (this.isInvalidDate && this.startDate && this.endDate) {
@@ -748,7 +751,6 @@ export class DaterangepickerComponent implements OnInit {
      * @param side left or right
      */
     timeChanged(timeEvent: any, side: SideEnum) {
-
         let hour = parseInt(this.timepickerVariables[side].selectedHour, 10);
         const minute = parseInt(this.timepickerVariables[side].selectedMinute, 10);
         const second = this.timePickerSeconds ? parseInt(this.timepickerVariables[side].selectedSecond, 10) : 0;
@@ -773,6 +775,14 @@ export class DaterangepickerComponent implements OnInit {
                 this.endDate = this.startDate.clone();
             } else if (this.endDate && this.endDate.format('YYYY-MM-DD') === start.format('YYYY-MM-DD') && this.endDate.isBefore(start)) {
                 this.setEndDate(start.clone());
+            } else if(!this.endDate && this.timePicker){
+                const startClone = this._getDateWithTime(start, SideEnum.right);
+                
+                if(startClone.isBefore(start)){
+                    this.timepickerVariables[SideEnum.right].selectedHour = hour;
+                    this.timepickerVariables[SideEnum.right].selectedMinute = minute;
+                    this.timepickerVariables[SideEnum.right].selectedSecond = second;
+                }
             }
         } else if (this.endDate) {
             const end = this.endDate.clone();


### PR DESCRIPTION
Made the changes I requested in #232. Now the time picker is almost always enabled. So I can now set time before both the start and end date are selected. 

Similar to this sometimes when selecting a date range I want to be able to select a single date. Currently a user must double click on the date to set it as the start and end date. It would be nice if when only one date was selected the time ranges would be available and used when the apply button is pressed. Right now if only the start date is selected it makes both the start and end the same date time.