### PR TITLE
Fix event emission regression

### DIFF
--- a/src/daterangepicker/daterangepicker.directive.ts
+++ b/src/daterangepicker/daterangepicker.directive.ts
@@ -341,7 +341,6 @@ export class DaterangepickerDirective implements OnInit, OnChanges, OnDestroy {
     hide(): void {
         if (this.overlayRef) {
             this.overlayRef.dispose();
-            this.destroy$.next();
             this.overlayRef = null;
             this.componentRef = null;
         }


### PR DESCRIPTION
This fix address https://github.com/fetrarij/ngx-daterangepicker-material/issues/269. I was too eager in the clean-up of event subscriptions, causing some events to break.