### PR TITLE
feat(icons): remove dependency of material icons

### DIFF
--- a/demo/src/assets/deeppurple-amber.css
+++ b/demo/src/assets/deeppurple-amber.css
@@ -100,6 +100,8 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }
 
 .mat-ripple-element {
   background-color: rgba(0, 0, 0, 0.1); }
@@ -1514,3 +1516,5 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }

--- a/demo/src/assets/indigo-pink.css
+++ b/demo/src/assets/indigo-pink.css
@@ -100,6 +100,8 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }
 
 .mat-ripple-element {
   background-color: rgba(0, 0, 0, 0.1); }
@@ -1514,3 +1516,5 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }

--- a/demo/src/assets/pink-bluegrey.css
+++ b/demo/src/assets/pink-bluegrey.css
@@ -100,6 +100,8 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }
 
 /*
 Orginal Style from https://github.com/Kelbster/highlightjs-material-dark-theme  (c) Kelby Gassmanl <kelby.gassman@gmail.com>
@@ -325,12 +327,24 @@ Orginal Style from https://github.com/Kelbster/highlightjs-material-dark-theme  
     width: 32px !important;
     height: 32px !important;
     line-height: 32px !important; }
-    .md-drppicker .navigation-button .mat-icon {
-      width: 24px !important;
-      height: 24px !important;
-      line-height: 24px !important; }
-    .md-drppicker .navigation-button .material-icons {
-      font-size: 24px !important; }
+    .md-drppicker .navigation-button .calendar-icon {
+      transform: rotate(180deg); }
+      .md-drppicker .navigation-button .calendar-icon::after {
+        display: block;
+        content: '';
+        height: 6px;
+        width: 6px;
+        border-width: 0 0 2px 2px;
+        border-style: solid;
+        position: absolute;
+        left: 50%;
+        top: 50%; }
+      .md-drppicker .navigation-button .calendar-icon.calendar-icon--left::after {
+        margin-left: 1px;
+        transform: translate(-50%, -50%) rotate(45deg); }
+      .md-drppicker .navigation-button .calendar-icon.calendar-icon--right::after {
+        margin-left: -1px;
+        transform: translate(-50%, -50%) rotate(225deg); }
   .md-drppicker .dropdowns {
     width: 60px; }
   .md-drppicker .dropdowns + .dropdowns {
@@ -379,6 +393,13 @@ Orginal Style from https://github.com/Kelbster/highlightjs-material-dark-theme  
     justify-content: center; }
     .md-drppicker .clear-button .clear-icon {
       font-size: 20px !important; }
+      .md-drppicker .clear-button .clear-icon svg {
+        width: 1em;
+        height: 1em;
+        fill: currentColor;
+        pointer-events: none;
+        top: .125em;
+        position: relative; }
   .md-drppicker .buttons {
     text-align: right;
     margin: 0 5px 5px 0; }
@@ -1876,3 +1897,5 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: white; }

--- a/demo/src/assets/purple-green.css
+++ b/demo/src/assets/purple-green.css
@@ -100,6 +100,8 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: rgba(0, 0, 0, 0.87); }
 
 /*
 Orginal Style from https://github.com/Kelbster/highlightjs-material-dark-theme  (c) Kelby Gassmanl <kelby.gassman@gmail.com>
@@ -1616,3 +1618,5 @@ app-footer .docs-footer-links a {
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.04);
     color: white; }
+  .md-drppicker .calendar-icon::after {
+    border-color: white; }

--- a/src/daterangepicker/daterangepicker-theme.scss
+++ b/src/daterangepicker/daterangepicker-theme.scss
@@ -68,5 +68,9 @@
                 }
             }
         }
+
+        .calendar-icon::after {
+            border-color: mat-color($foreground, text);
+        }
     }
 }

--- a/src/daterangepicker/daterangepicker.component.html
+++ b/src/daterangepicker/daterangepicker.component.html
@@ -40,7 +40,7 @@
                         >
                             <th>
                                 <button class="navigation-button" mat-icon-button (click)="clickPrev(sideEnum.left)">
-                                    <mat-icon>keyboard_arrow_left</mat-icon>
+                                    <span class="calendar-icon calendar-icon--left"></span>
                                 </button>
                             </th>
                         </ng-container>
@@ -94,7 +94,7 @@
                         >
                             <th>
                                 <button class="navigation-button" mat-icon-button (click)="clickNext(sideEnum.left)">
-                                    <mat-icon>keyboard_arrow_right</mat-icon>
+                                    <span class="calendar-icon calendar-icon--right"></span>
                                 </button>
                             </th>
                         </ng-container>
@@ -225,7 +225,7 @@
                         >
                             <th>
                                 <button class="navigation-button" mat-icon-button (click)="clickPrev(sideEnum.right)">
-                                    <mat-icon>keyboard_arrow_left</mat-icon>
+                                    <span class="calendar-icon calendar-icon--left"></span>
                                 </button>
                             </th>
                         </ng-container>
@@ -279,7 +279,7 @@
                         >
                             <th>
                                 <button class="navigation-button" mat-icon-button (click)="clickNext(sideEnum.right)">
-                                    <mat-icon>keyboard_arrow_right</mat-icon>
+                                    <span class="calendar-icon calendar-icon--right"></span>
                                 </button>
                             </th>
                         </ng-container>
@@ -401,7 +401,11 @@
             <button *ngIf="showClearButton" mat-raised-button type="button" [title]="locale.clearLabel" (click)="clear()">
                 <span class="clear-button">
                     {{ locale.clearLabel }}
-                    <mat-icon [inline]="true" class="clear-icon">delete</mat-icon>
+                    <span class="clear-icon">
+                        <svg viewBox="0 0 24 24">
+                            <path fill="currentColor" d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z" />
+                        </svg>
+                    </span>
                 </span>
             </button>
             <button *ngIf="showCancel" mat-raised-button (click)="clickCancel()">{{ locale.cancelLabel }}</button>

--- a/src/daterangepicker/daterangepicker.component.scss
+++ b/src/daterangepicker/daterangepicker.component.scss
@@ -228,14 +228,33 @@ $md-drppicker-cell-border-size: 1px !default;
         height: 32px !important;
         line-height: 32px !important;
 
-        .mat-icon {
-            width: 24px !important;
-            height: 24px !important;
-            line-height: 24px !important;
-        }
+        .calendar-icon {
+            transform:rotate(180deg);
+            &::after {
+                display: block;
+                content: '';
+                height: 6px;
+                width: 6px;
+                border-width: 0 0 2px 2px;
+                border-style: solid;
+                position: absolute;
+                left: 50%;
+                top: 50%;
+            }
 
-        .material-icons {
-            font-size: 24px !important;
+            &.calendar-icon--left {
+                &::after {
+                    margin-left: 1px;
+                    transform: translate(-50%, -50%) rotate(45deg);
+                }
+            }
+            
+            &.calendar-icon--right {
+                &::after {
+                    margin-left: -1px;
+                    transform: translate(-50%, -50%) rotate(225deg);
+                }
+            }
         }
     }
 
@@ -322,6 +341,15 @@ $md-drppicker-cell-border-size: 1px !default;
 
         .clear-icon {
             font-size: 20px !important;
+
+            svg {
+                width: 1em;
+                height: 1em;
+                fill: currentColor;
+                pointer-events: none;
+                top: .125em;
+                position: relative;
+            }
         }
     }
 

--- a/src/daterangepicker/daterangepicker.module.ts
+++ b/src/daterangepicker/daterangepicker.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { DaterangepickerComponent } from './daterangepicker.component';
 import { LocaleConfig, LOCALE_CONFIG } from './daterangepicker.config';
@@ -12,7 +11,7 @@ import { LocaleService } from './locale.service';
 
 @NgModule({
     declarations: [DaterangepickerComponent, DaterangepickerDirective],
-    imports: [CommonModule, FormsModule, ReactiveFormsModule, MatButtonModule, MatIconModule, MatSelectModule, OverlayModule],
+    imports: [CommonModule, FormsModule, ReactiveFormsModule, MatButtonModule, MatSelectModule, OverlayModule],
     exports: [DaterangepickerComponent, DaterangepickerDirective],
 })
 export class NgxDaterangepickerMd {


### PR DESCRIPTION
Currently material icons need to be loaded in order to display the icons of the datepicker. This pull request removes this dependency. Arrow icons can be drawn with css, whereas a separate svg element has been used for the trash icon.

Fixes #276 