### PR TITLE
Update daterangepicker.component.scss

### DIFF
--- a/src/daterangepicker/daterangepicker.component.scss
+++ b/src/daterangepicker/daterangepicker.component.scss
@@ -174,10 +174,10 @@ $input-height: 3rem !default;
       transform-origin: 0 0;
     }
     &.drops-down-center {
-      transform-origin: 50%% 0;
+      transform-origin: 50% 0;
     }
     &.drops-up-center {
-      transform-origin: 50%% 100%;
+      transform-origin: 50% 100%;
     }
     
     .calendar {


### PR DESCRIPTION
Drops='up' is not working because of double %% in the scss file. This will fix it.