### PR TITLE
Support string type for minDate & maxDate props

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Demo: https://fetrarij.github.io/ngx-daterangepicker-material/
 ## Versions
 
 | Angular| ngx-daterangepicker-material|
-| ------|:------:| 
+| ------|:------:|
 | >=9.0.0  | v4.x.x |
 | <9.0.0  | v2.x.x |
 | ~~>=9.0.0 depends on @angular/material~~ |~~v3.x~~ |
@@ -110,7 +110,7 @@ You can use the component directly in your templates, which will set its `inline
 
 ### minDate, maxDate
 
- >To set the minimal and maximal date, these options are a moment date
+ >To set the minimal and maximal date, these options are either a moment date or string in [ISO](https://www.w3.org/QA/Tips/iso-date) format
 
 ### dateLimit
 

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -43,10 +43,38 @@ export class DaterangepickerComponent implements OnInit {
     // used in template for compile time support of enum values.
     sideEnum = SideEnum;
 
+    _minDate: _moment.Moment;
     @Input()
-    minDate: _moment.Moment = null;
+    set minDate(value: _moment.Moment | string) {
+        if (_moment.isMoment(value)) {
+            this._minDate = value;
+        }
+        else if (typeof value === 'string') {
+            this._minDate = moment(value)
+        } else {
+            this._minDate = null;
+        }
+    };
+    getMinDate(): _moment.Moment | null {
+        return this._minDate;
+    }
+
+    _maxDate: _moment.Moment;
     @Input()
-    maxDate: _moment.Moment = null;
+    set maxDate(value: _moment.Moment | string) {
+        if (_moment.isMoment(value)) {
+            this._maxDate = value;
+        }
+        else if (typeof value === 'string') {
+            this._maxDate = moment(value)
+        } else {
+            this._maxDate = null;
+        }
+    }
+    getMaxDate(): _moment.Moment | null {
+        return this._maxDate;
+    }
+
     @Input()
     autoApply: Boolean = false;
     @Input()
@@ -205,10 +233,10 @@ export class DaterangepickerComponent implements OnInit {
                     }
                     // If the start or end date exceed those allowed by the minDate or maxSpan
                     // options, shorten the range to the allowable period.
-                    if (this.minDate && start.isBefore(this.minDate)) {
-                        start = this.minDate.clone();
+                    if (this.getMinDate() && start.isBefore(this.getMinDate())) {
+                        start = this.getMinDate().clone();
                     }
-                    let maxDate = this.maxDate;
+                    let maxDate = this.getMaxDate();
                     if (this.maxSpan && maxDate && start.clone().add(this.maxSpan).isAfter(maxDate)) {
                         maxDate = start.clone().add(this.maxSpan);
                     }
@@ -217,7 +245,7 @@ export class DaterangepickerComponent implements OnInit {
                     }
                     // If the end of the range is before the minimum or the start of the range is
                     // after the maximum, don't display this range option at all.
-                    if ((this.minDate && end.isBefore(this.minDate, this.timePicker ? 'minute' : 'day'))
+                    if ((this.getMinDate() && end.isBefore(this.getMinDate(), this.timePicker ? 'minute' : 'day'))
                     || (maxDate && start.isAfter(maxDate, this.timePicker ? 'minute' : 'day'))) {
                         continue;
                     }
@@ -244,12 +272,12 @@ export class DaterangepickerComponent implements OnInit {
         }
 
     }
-    renderTimePicker(side: SideEnum) {        
+    renderTimePicker(side: SideEnum) {
         let selected, minDate;
-        const maxDate = this.maxDate;
+        const maxDate = this.getMaxDate();
         if (side === SideEnum.left) {
             selected = this.startDate.clone(),
-            minDate = this.minDate;
+            minDate = this.getMinDate();
         } else if (side === SideEnum.right && this.endDate) {
             selected = this.endDate.clone(),
             minDate = this.startDate;
@@ -299,7 +327,7 @@ export class DaterangepickerComponent implements OnInit {
                 this.timepickerVariables[side].disabledHours.push(i);
             }
         }
-        
+
         // generate minutes
         for (let i = 0; i < 60; i += this.timePickerIncrement) {
             const padded = i < 10 ? '0' + i : i;
@@ -407,14 +435,14 @@ export class DaterangepickerComponent implements OnInit {
             calendar[row][col] = curDate.clone().hour(hour).minute(minute).second(second);
             curDate.hour(12);
 
-            if (this.minDate && calendar[row][col].format('YYYY-MM-DD') === this.minDate.format('YYYY-MM-DD') &&
-            calendar[row][col].isBefore(this.minDate) && side === 'left') {
-                calendar[row][col] = this.minDate.clone();
+            if (this.getMinDate() && calendar[row][col].format('YYYY-MM-DD') === this.getMinDate().format('YYYY-MM-DD') &&
+            calendar[row][col].isBefore(this.getMinDate()) && side === 'left') {
+                calendar[row][col] = this.getMinDate().clone();
             }
 
-            if (this.maxDate && calendar[row][col].format('YYYY-MM-DD') === this.maxDate.format('YYYY-MM-DD') &&
-            calendar[row][col].isAfter(this.maxDate) && side === 'right') {
-                calendar[row][col] = this.maxDate.clone();
+            if (this.getMaxDate() && calendar[row][col].format('YYYY-MM-DD') === this.getMaxDate().format('YYYY-MM-DD') &&
+            calendar[row][col].isAfter(this.getMaxDate()) && side === 'right') {
+                calendar[row][col] = this.getMaxDate().clone();
             }
         }
 
@@ -427,8 +455,8 @@ export class DaterangepickerComponent implements OnInit {
         //
         // Display the calendar
         //
-        const minDate = side === 'left' ? this.minDate : this.startDate;
-        let maxDate = this.maxDate;
+        const minDate = side === 'left' ? this.getMinDate() : this.startDate;
+        let maxDate = this.getMaxDate();
         // adjust maxDate to reflect the dateLimit setting in order to
         // grey out end dates beyond the dateLimit
         if (this.endDate === null && this.dateLimit) {
@@ -503,16 +531,16 @@ export class DaterangepickerComponent implements OnInit {
         }
 
 
-        if (this.minDate && this.startDate.isBefore(this.minDate)) {
-            this.startDate = this.minDate.clone();
+        if (this.getMinDate() && this.startDate.isBefore(this.getMinDate())) {
+            this.startDate = this.getMinDate().clone();
             if (this.timePicker && this.timePickerIncrement) {
                 this.startDate.minute(Math.round(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
 
         }
 
-        if (this.maxDate && this.startDate.isAfter(this.maxDate)) {
-            this.startDate = this.maxDate.clone();
+        if (this.getMaxDate() && this.startDate.isAfter(this.getMaxDate())) {
+            this.startDate = this.getMaxDate().clone();
             if (this.timePicker && this.timePickerIncrement) {
                 this.startDate.minute(Math.floor(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
@@ -548,8 +576,8 @@ export class DaterangepickerComponent implements OnInit {
             this.endDate = this.startDate.clone();
         }
 
-        if (this.maxDate && this.endDate.isAfter(this.maxDate)) {
-            this.endDate = this.maxDate.clone();
+        if (this.getMaxDate() && this.endDate.isAfter(this.getMaxDate())) {
+            this.endDate = this.getMaxDate().clone();
         }
 
         if (this.dateLimit && this.startDate.clone().add(this.dateLimit, 'day').isBefore(this.endDate)) {
@@ -614,9 +642,9 @@ export class DaterangepickerComponent implements OnInit {
                 this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');
             }
         }
-        if (this.maxDate && this.linkedCalendars && !this.singleDatePicker && this.rightCalendar.month > this.maxDate) {
-            this.rightCalendar.month = this.maxDate.clone().date(2);
-            this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
+        if (this.getMaxDate() && this.linkedCalendars && !this.singleDatePicker && this.rightCalendar.month > this.getMaxDate()) {
+            this.rightCalendar.month = this.getMaxDate().clone().date(2);
+            this.leftCalendar.month = this.getMaxDate().clone().date(2).subtract(1, 'month');
         }
     }
     /**
@@ -785,7 +813,7 @@ export class DaterangepickerComponent implements OnInit {
                 this.setEndDate(start.clone());
             } else if(!this.endDate && this.timePicker){
                 const startClone = this._getDateWithTime(start, SideEnum.right);
-                
+
                 if(startClone.isBefore(start)){
                     this.timepickerVariables[SideEnum.right].selectedHour = hour;
                     this.timepickerVariables[SideEnum.right].selectedMinute = minute;
@@ -827,17 +855,17 @@ export class DaterangepickerComponent implements OnInit {
             }
         }
 
-        if (this.minDate) {
-            if (year < this.minDate.year() || (year === this.minDate.year() && month < this.minDate.month())) {
-                month = this.minDate.month();
-                year = this.minDate.year();
+        if (this.getMinDate()) {
+            if (year < this.getMinDate().year() || (year === this.getMinDate().year() && month < this.getMinDate().month())) {
+                month = this.getMinDate().month();
+                year = this.getMinDate().year();
             }
         }
 
-        if (this.maxDate) {
-            if (year > this.maxDate.year() || (year === this.maxDate.year() && month > this.maxDate.month())) {
-                month = this.maxDate.month();
-                year = this.maxDate.year();
+        if (this.getMaxDate()) {
+            if (year > this.getMaxDate().year() || (year === this.getMaxDate().year() && month > this.getMaxDate().month())) {
+                month = this.getMaxDate().month();
+                year = this.getMaxDate().year();
             }
         }
         this.calendarVariables[side].dropdowns.currentYear = year;
@@ -1011,7 +1039,7 @@ export class DaterangepickerComponent implements OnInit {
                 if (!this.alwaysShowCalendars) {
                     return  this.clickApply();
                 }
-                if (this.maxDate && this.maxDate.isSame(dates[0], 'month')) {
+                if (this.getMaxDate() && this.getMaxDate().isSame(dates[0], 'month')) {
                     this.rightCalendar.month.month(dates[0].month());
                     this.rightCalendar.month.year(dates[0].year());
                     this.leftCalendar.month.month(dates[0].month() - 1);
@@ -1112,17 +1140,17 @@ export class DaterangepickerComponent implements OnInit {
       }
       const rangeMarkers = this.ranges[range];
       const areBothBefore = rangeMarkers.every( date => {
-        if (!this.minDate) {
+        if (!this.getMinDate()) {
             return false;
         }
-        return date.isBefore(this.minDate);
+        return date.isBefore(this.getMinDate());
       });
 
       const areBothAfter = rangeMarkers.every( date => {
-        if (!this.maxDate) {
+        if (!this.getMaxDate()) {
             return false;
         }
-        return date.isAfter(this.maxDate);
+        return date.isAfter(this.getMaxDate());
       });
       return (areBothBefore || areBothAfter);
     }
@@ -1219,7 +1247,7 @@ export class DaterangepickerComponent implements OnInit {
                     classes.push(this.lastMonthDayClass);
                 }
                 // don't allow selection of dates before the minimum date
-                if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day')) {
+                if (this.getMinDate() && calendar[row][col].isBefore(this.getMinDate(), 'day')) {
                     classes.push('off', 'disabled');
                 }
                 // don't allow selection of dates after the maximum date


### PR DESCRIPTION
As per [discussion](https://github.com/fetrarij/ngx-daterangepicker-material/issues/358) would be great to have support for luxon library.

But in general momentjs works fine in scope of this module and we have only two `Input()` props that we receiving from the parent component with strictly defined type `Moment`. If we allow users to pass string in [ISO](https://www.w3.org/QA/Tips/iso-date) format it will give users the ability to get rid of usage moment in their code base.