### PR TITLE
added return types for isCustomDate() and singleDateSelect in dualCalanderView

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -80,6 +80,8 @@ export class DaterangepickerComponent implements OnInit {
     @Input()
     singleDatePicker: Boolean = false;
     @Input()
+    singleDateSelect: Boolean = false;
+    @Input()
     showDropdowns: Boolean = false;
     @Input()
     showWeekNumbers: Boolean = false;
@@ -988,7 +990,7 @@ export class DaterangepickerComponent implements OnInit {
             }
         }
 
-        if (this.singleDatePicker) {
+        if (this.singleDatePicker || this.singleDateSelect) {
             this.setEndDate(this.startDate);
             this.updateElement();
             if (this.autoApply) {

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -598,7 +598,7 @@ export class DaterangepickerComponent implements OnInit {
         return false;
     }
     @Input()
-    isCustomDate(date) {
+    isCustomDate(date): boolean | string {
         return false;
     }
     @Input()

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -598,7 +598,7 @@ export class DaterangepickerComponent implements OnInit {
         return false;
     }
     @Input()
-    isCustomDate(date): boolean | string {
+    isCustomDate(date): boolean | string | string[] {
         return false;
     }
     @Input()


### PR DESCRIPTION
Getting error of Type '(date: any) => string | boolean' is not assignable to type '(date: any) => boolean' in angular 11

so added return types for isCustomDate()

isCustomDate(date): boolean | string {
        return false;
    }