### PR TITLE
Add missing import for dayjs week function

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -11,6 +11,8 @@ import * as LocalizedFormat from 'dayjs/plugin/localizedFormat';
 dayjs.extend(LocalizedFormat);
 import * as isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
+import * as week from 'dayjs/plugin/weekOfYear'
+dayjs.extend(week)
 import * as customParseFormat from 'dayjs/plugin/customParseFormat'
 dayjs.extend(customParseFormat);
 


### PR DESCRIPTION
So that showWeekNumbers can be used without causing an error.