### PR TITLE
Adding dateLimit for both dates before startDate and after

### DIFF
--- a/demo/src/app/simple/simple.component.html
+++ b/demo/src/app/simple/simple.component.html
@@ -53,6 +53,7 @@
                                   [timePicker]="true"
                                   [locale]="{applyLabel: 'Done', firstDay: 1}"></ngx-daterangepicker-material>
     <br>
-    <p>Choosed date (after changes): {{inlineDateTime | json}}</p>
+    <p>Choosed date (after changes): {{selected | json}}</p>
+    <button (click)="increaseDateTime()">Increase dateTime</button>
   </div>
 </div>

--- a/demo/src/app/simple/simple.component.ts
+++ b/demo/src/app/simple/simple.component.ts
@@ -34,7 +34,7 @@ export class SimpleComponent implements OnInit {
   }
 
   choosedDateTime(e) {
-    this.inlineDateTime = e;
+    this.selected = e;
   }
   open(e) {
     this.pickerDirective.open(e);
@@ -42,5 +42,8 @@ export class SimpleComponent implements OnInit {
   clear(e) {
     // this.picker.clear(); // we can do
     this.selected = null; // now we can do
+  }
+  increaseDateTime() {
+    this.selected.endDate = this.selected.endDate.clone().add(1, 'day').add(1, 'hour');
   }
 }

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -11,6 +11,8 @@ import * as LocalizedFormat from 'dayjs/plugin/localizedFormat';
 dayjs.extend(LocalizedFormat);
 import * as isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
+import * as week from 'dayjs/plugin/weekOfYear'
+dayjs.extend(week)
 import * as customParseFormat from 'dayjs/plugin/customParseFormat'
 dayjs.extend(customParseFormat);
 

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 import * as _dayjs from 'dayjs';
 import { LocaleConfig } from './daterangepicker.config';
@@ -36,7 +36,7 @@ export enum SideEnum {
         multi: true
     }]
 })
-export class DaterangepickerComponent implements OnInit {
+export class DaterangepickerComponent implements OnInit, OnChanges {
     private _old: {start: any, end: any} = {start: null, end: null};
     chosenLabel: string;
     calendarVariables: {left: any, right: any} = {left: {}, right: {}};
@@ -188,6 +188,12 @@ export class DaterangepickerComponent implements OnInit {
         this.startDateChanged = new EventEmitter();
         this.endDateChanged = new EventEmitter();
         this.cancelClicked = new EventEmitter();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if ((changes.startDate || changes.endDate) && this.inline) {
+            this.updateView();
+        }
     }
 
     ngOnInit() {

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -469,14 +469,22 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
         //
         // Display the calendar
         //
-        const minDate = side === 'left' ? this.getMinDate() : this.startDate;
+        let minDate = side === 'left' ? this.getMinDate() : this.startDate;
         let maxDate = this.getMaxDate();
         // adjust maxDate to reflect the dateLimit setting in order to
         // grey out end dates beyond the dateLimit
         if (this.endDate === null && this.dateLimit) {
             const maxLimit = this.startDate.clone().add(this.dateLimit, 'day').endOf('day');
-                if (!maxDate || maxLimit.isBefore(maxDate)) {
+            if (!maxDate || maxLimit.isBefore(maxDate)) {
                 maxDate = maxLimit;
+            }
+
+            if(this.customRangeDirection) {
+                minDate = this.getMinDate();
+                const minLimit = this.startDate.clone().subtract(this.dateLimit, 'day').endOf('day');
+                if (!minDate || minLimit.isAfter(minDate)) {
+                    minDate = minLimit;
+                }
             }
         }
         this.calendarVariables[side] = {

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -11,6 +11,9 @@ import * as LocalizedFormat from 'dayjs/plugin/localizedFormat';
 dayjs.extend(LocalizedFormat);
 import * as isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
+import * as customParseFormat from 'dayjs/plugin/customParseFormat'
+dayjs.extend(customParseFormat);
+
 
 export enum SideEnum {
     left = 'left',


### PR DESCRIPTION
Hi! What's up? I am not very good with English, Sorry! 

I made a small fix to the dateLimit. I add dateLimt for both dates before startDate and after with set customRangeDirection true.

[ How is it today ] It isn't set o dateLimit for before startDate

![ev01](https://user-images.githubusercontent.com/6425342/154730011-8c4a183f-2ea3-474b-a98f-c36b154fc7bf.gif)


[ Fix dateLimit ]

![ev02](https://user-images.githubusercontent.com/6425342/154730099-a404c8af-2092-46aa-982b-bb102f679ab5.gif)
