### PR TITLE
Fix :: Removed ranges division on empty ranges

### DIFF
--- a/src/daterangepicker/daterangepicker.component.html
+++ b/src/daterangepicker/daterangepicker.component.html
@@ -8,16 +8,19 @@
     'double': !singleDatePicker && showCalInRanges,
     'show-ranges': rangesArray.length
 }" [class]="'drops-' + drops + '-' + opens">
-    <div class="ranges">
-        <ul>
-          <li *ngFor="let range of rangesArray">
-            <button type="button"
+    <ng-container *ngIf="rangesArray.length">
+        <div class="ranges">
+            <ul>
+              <li *ngFor="let range of rangesArray">
+                <button 
+                    type="button"
                     (click)="clickRange($event, range)"
                     [disabled]="disableRange(range)"
                     [ngClass]="{'active': range === chosenRange}">{{range}}</button>
-          </li>
-        </ul>
-    </div>
+              </li>
+            </ul>
+        </div>
+    </ng-container>
     <div class="calendar" [ngClass]="{right: singleDatePicker, left: !singleDatePicker}"
         *ngIf="showCalInRanges">
         <div class="calendar-table">


### PR DESCRIPTION
We are using `ngx-daterangepicker-material` with [Nebular Theme](https://akveo.github.io/nebular/) and having some default css issue. So i have removed "ranges div" from DOM instead of applying CSS. Thanks.

- [x] Before

![image](https://user-images.githubusercontent.com/41804588/163566625-681f71f8-38c2-45b6-b52f-dcf0d470d3ee.png)

- [ ] After

![image](https://user-images.githubusercontent.com/41804588/163566687-1e5bca73-38f1-4da2-8471-69ed2325c1ca.png)

Note: If such changes not needed feel free to close this PR.

