### PR TITLE
ts changes

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -302,7 +302,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
   }
 
   // accessors
-  get minDate(): dayjs.Dayjs | null {
+  get minDate(): dayjs.Dayjs {
     return this.minDateHolder;
   }
 
@@ -341,7 +341,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
   }
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
-  get maxDate(): dayjs.Dayjs | null {
+  get maxDate(): dayjs.Dayjs {
     return this.maxDateHolder;
   }
 


### PR DESCRIPTION
fixes #471

Describe the bug
Code is not compiling due to this error in daterangepicker.component.d.ts :
`The return type of a 'get' accessor must be assignable to its 'set' accessor type Type 'null' is not assignable to type 'string | Dayjs'.`

The issue is valid for attributes maxDate and minDate

To Reproduce
Steps to reproduce the behavior:

Compile
Expected behavior
maxDate and minDate should have the same type so it's follow the typescript rules