### PR TITLE
fix: typo on string closing inside code tag

### DIFF
--- a/demo/src/app/custom-ranges/custom-ranges.component.html
+++ b/demo/src/app/custom-ranges/custom-ranges.component.html
@@ -58,7 +58,7 @@
   [isInvalidDate] = "isInvalidDate"
   [showClearButton]="true"
 
-  placeholder="Select please.../&gt;</code>
+  placeholder="Select please..."/&gt;</code>
     </pre>
     </div>
     <div class="col s6">


### PR DESCRIPTION
The text displaying the sample code has a typo, missing the final quote on the placeholder string potentially misleading users if they take it as sample code.