### PR TITLE
When updating the calendar view, if daterange selected, don't change current month in view

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -844,6 +844,11 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
         return;
       }
       if (this.startDate) {
+        // we want to stay on whatever months are in view if date range is set and both calendar sides have a month already.  e.g. when 
+        // user clicks on the end date, we want to stay on current month in view
+        if (this.leftCalendar.month && this.rightCalendar.month) {
+          return;
+        }
         this.leftCalendar.month = this.startDate.clone().date(2);
         if (!this.linkedCalendars && (this.endDate.month() !== this.startDate.month() || this.endDate.year() !== this.startDate.year())) {
           this.rightCalendar.month = this.endDate.clone().date(2);


### PR DESCRIPTION
Fix for #528


https://github.com/fetrarij/ngx-daterangepicker-material/assets/1899380/59e6f422-fca3-401f-a494-0397ab1956fb