### PR TITLE
Fix the enddate correction to the time picker increment

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -798,7 +798,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
     }
 
     if (this.timePicker && this.timePickerIncrement) {
-      this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
+      this.endDate = this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
     }
 
     if (this.endDate.isBefore(this.startDate)) {
@@ -1425,7 +1425,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
       const minute = parseInt(String(this.timepickerVariables[side].selectedMinute), 10);
       const second = this.timePickerSeconds ? parseInt(String(this.timepickerVariables[side].selectedSecond), 10) : 0;
       return date.clone().hour(hour).minute(minute).second(second);
-  
+
     }else{
       return;
     }


### PR DESCRIPTION
The minutes of the end date were corrected to the time picker increment, but this was not saved to the end date. The result was if time picker increment is 5, the minute drop down would always show 0, unless the minutes would be dividable by 5.