### PR TITLE
fix locale customization not being applied when using `locale.locale` + fix locale custom format not being applied on display label

### DIFF
--- a/demo/src/app/locale/locale.component.html
+++ b/demo/src/app/locale/locale.component.html
@@ -7,6 +7,9 @@
             [(ngModel)]="selected"
             class="form-control"
             placeholder="Choose date"
+            [showCustomRangeLabel]="true"
+            [ranges]="datesRanges"
+            [alwaysShowCalendars]="true"
             [locale]="{ locale, applyLabel: 'Ack', displayFormat: 'YYYY MMM DD', separator: ' :: ' }" />
     </div>
 

--- a/demo/src/app/locale/locale.component.html
+++ b/demo/src/app/locale/locale.component.html
@@ -7,7 +7,7 @@
             [(ngModel)]="selected"
             class="form-control"
             placeholder="Choose date"
-            [locale]="{ locale, applyLabel: 'Ack' }" />
+            [locale]="{ locale, applyLabel: 'Ack', displayFormat: 'YYYY MMM DD', separator: ' :: ' }" />
     </div>
-  
+
 </div>

--- a/demo/src/app/locale/locale.component.ts
+++ b/demo/src/app/locale/locale.component.ts
@@ -13,8 +13,16 @@ dayjs.extend(utc);
 export class LocaleComponent implements OnInit {
   selected: { startDate: dayjs.Dayjs; endDate: dayjs.Dayjs };
   locale = fr;
-  constructor() {}
+  datesRanges: any = {
+    ['Today']: [dayjs(), dayjs()],
+    ['Yesterday']: [dayjs().subtract(1, 'days'), dayjs().subtract(1, 'days')],
+    ['Last 7 days']: [dayjs().subtract(6, 'days'), dayjs()],
+    ['Last 30 days']: [dayjs().subtract(29, 'days'), dayjs()],
+    ['This month']: [dayjs().startOf('month'), dayjs().endOf('month')],
+    ['Last month']: [dayjs().subtract(1, 'month').startOf('month'), dayjs().subtract(1, 'month').endOf('month')],
+  };
 
+  constructor() {}
 
   ngOnInit(): void {}
 }

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -324,8 +324,16 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
 
   @Input() set locale(value: LocaleConfig) {
     this.localeHolder = { ...this.localeHolderService.config, ...value };
+
     if (value.locale) {
-      this.localeHolder = this.localeHolderService.configWithLocale(value.locale);
+      const tempValue = { ...value }; // make copy of value
+      // remove fields being applied from value.locale
+      delete tempValue.daysOfWeek;
+      delete tempValue.monthNames;
+      delete tempValue.firstDay;
+
+      // combine config with locale and customized LocaleConfig
+      this.localeHolder = { ...this.localeHolderService.configWithLocale(value.locale), ...tempValue };
     }
   }
 
@@ -844,7 +852,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
         return;
       }
       if (this.startDate) {
-        // we want to stay on whatever months are in view if date range is set and both calendar sides have a month already.  e.g. when 
+        // we want to stay on whatever months are in view if date range is set and both calendar sides have a month already.  e.g. when
         // user clicks on the end date, we want to stay on current month in view
         if (this.leftCalendar.month && this.rightCalendar.month) {
           return;

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -905,10 +905,14 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
         ) {
           this.chosenLabel = this.chosenRange;
         } else {
-          this.chosenLabel =
-            (this.localeHolder.locale ? this.startDate.locale(this.localeHolder.locale).format(format) : this.startDate.format(format)) +
-            this.locale.separator +
-            (this.localeHolder.locale ? this.endDate.locale(this.localeHolder.locale).format(format) : this.endDate.format(format));
+          const formattedStartDate = this.localeHolder.locale
+            ? this.startDate.locale(this.localeHolder.locale).format(format)
+            : this.startDate.format(format);
+          const formattedEndDate = this.localeHolder.locale
+            ? this.endDate.locale(this.localeHolder.locale).format(format)
+            : this.endDate.format(format);
+
+          this.chosenLabel = formattedStartDate + this.locale.separator + formattedEndDate;
         }
       }
     } else if (this.autoUpdateInput) {

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -905,11 +905,16 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
         ) {
           this.chosenLabel = this.chosenRange;
         } else {
-          this.chosenLabel = this.startDate.format(format) + this.locale.separator + this.endDate.format(format);
+          this.chosenLabel =
+            (this.localeHolder.locale ? this.startDate.locale(this.localeHolder.locale).format(format) : this.startDate.format(format)) +
+            this.locale.separator +
+            (this.localeHolder.locale ? this.endDate.locale(this.localeHolder.locale).format(format) : this.endDate.format(format));
         }
       }
     } else if (this.autoUpdateInput) {
-      this.chosenLabel = this.startDate.format(format);
+      this.chosenLabel = this.localeHolder.locale
+        ? this.startDate.locale(this.localeHolder.locale).format(format)
+        : this.startDate.format(format);
     }
   }
 


### PR DESCRIPTION
this pull request addresses two issues:
* locale customization is not being applied when `locale.locale` is used

[customization_not_acknowledged.webm](https://github.com/user-attachments/assets/2efe00ec-41bc-4165-a82d-fb771def5f15)
* when `format` or `displayFormat` is defined, it is not applied when calculating `chosenLabel`

[formatting_not_using_locale.webm](https://github.com/user-attachments/assets/512bd2f5-ed3a-488a-a47a-f10df50cddb1)

with the fixes included in this pull request

[with_customization_and_locale_formatting.webm](https://github.com/user-attachments/assets/2c907963-7e43-451b-84fc-d091b0ada082)
