### PR TITLE
Fix: singleDatePicker active class not showing on single date when timePickerIncrement is set

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -1578,8 +1578,11 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
           classes.push('active', 'start-date');
         }
         // highlight the currently selected end date
+        // for singleDatePicker, don't add end-date class if it's the same as start date
         if (this.endDate != null && calendar[row][col].format('YYYY-MM-DD') === this.endDate.format('YYYY-MM-DD')) {
-          classes.push('active', 'end-date');
+          if (!this.singleDatePicker || this.endDate.format('YYYY-MM-DD') !== this.startDate.format('YYYY-MM-DD')) {
+            classes.push('active', 'end-date');
+          }
         }
         // highlight dates in-between the selected dates
         if (


### PR DESCRIPTION
## Description

When `timePickerIncrement` is set with `singleDatePicker` enabled, the component was applying both 'start-date' and 'end-date' classes to the same date cell (since both startDate and endDate are set to the same value in single date picker mode). This caused the date to display with an incorrect visual style.

## The Problem

In single date picker mode with time picker increment:
- The active class was appearing on both dates instead of just the selected single date
- This was because both 'start-date' and 'end-date' classes were being applied when the dates matched

## The Solution

The fix prevents adding the 'end-date' class when in singleDatePicker mode and the end date matches the start date, ensuring only the 'start-date' class is applied.

## Changes Made

Modified the `buildCells` method in `src/daterangepicker/daterangepicker.component.ts`:
- Added a condition to prevent adding the 'end-date' class when in singleDatePicker mode and both dates are the same
- This ensures the date displays with only the 'start-date' class styling

## Related Issue

Fixes #351